### PR TITLE
Add BPBreIDSORT tracker

### DIFF
--- a/ultralytics/cfg/trackers/bpbreid.yaml
+++ b/ultralytics/cfg/trackers/bpbreid.yaml
@@ -1,0 +1,19 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
+# Default settings for body part-based BoT-SORT tracker
+tracker_type: bpbreid
+track_high_thresh: 0.25
+track_low_thresh: 0.1
+new_track_thresh: 0.25
+track_buffer: 30
+match_thresh: 0.8
+fuse_score: True
+
+# BoT-SORT settings
+gmc_method: sparseOptFlow
+# ReID settings
+proximity_thresh: 0.5
+appearance_thresh: 0.8
+with_reid: True
+model: yolo11n-pose.pt
+

--- a/ultralytics/trackers/README.md
+++ b/ultralytics/trackers/README.md
@@ -33,6 +33,7 @@ Ultralytics YOLO supports the following tracking algorithms. Enable them by pass
 
 - **BoT-SORT:** Use [`botsort.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/botsort.yaml) to enable this tracker. Based on the [BoT-SORT paper](https://arxiv.org/abs/2206.14651) and its official [code implementation](https://github.com/NirAharon/BoT-SORT).
 - **ByteTrack:** Use [`bytetrack.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/bytetrack.yaml) to enable this tracker. Based on the [ByteTrack paper](https://arxiv.org/abs/2110.06864) and its official [code implementation](https://github.com/ifzhang/ByteTrack).
+- **BPBreIDSORT:** Use [`bpbreid.yaml`](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/trackers/bpbreid.yaml) to enable this tracker. It extends BoT-SORT with a body part-based ReID model.
 
 The default tracker is **BoT-SORT**.
 

--- a/ultralytics/trackers/__init__.py
+++ b/ultralytics/trackers/__init__.py
@@ -2,6 +2,7 @@
 
 from .bot_sort import BOTSORT
 from .byte_tracker import BYTETracker
+from .bpbreid_sort import BPBreIDSORT
 from .track import register_tracker
 
-__all__ = "register_tracker", "BOTSORT", "BYTETracker"  # allow simpler import
+__all__ = "register_tracker", "BOTSORT", "BYTETracker", "BPBreIDSORT"  # allow simpler import

--- a/ultralytics/trackers/bpbreid_sort.py
+++ b/ultralytics/trackers/bpbreid_sort.py
@@ -1,0 +1,53 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+"""Body part-based tracker using BoT-SORT with pose ReID."""
+
+from typing import Any, List
+
+import numpy as np
+import torch
+
+from ultralytics.utils.plotting import save_one_box
+from ultralytics.utils.ops import xywh2xyxy
+
+from .bot_sort import BOTSORT
+
+
+class BodyPartReID:
+    """Simplified body part-based ReID using a pose model."""
+
+    PART_IDXS = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9, 10, 11], [12, 13, 14, 15, 16]]
+
+    def __init__(self, model: str = "yolo11n-pose.pt"):
+        from ultralytics import YOLO
+
+        self.model = YOLO(model)
+        # warmup to create predictor
+        self.model.predict([np.zeros((10, 10, 3), dtype=np.uint8)], verbose=False)
+
+    def __call__(self, img: np.ndarray, dets: np.ndarray) -> List[np.ndarray]:
+        crops = [save_one_box(det, img, save=False) for det in xywh2xyxy(torch.from_numpy(dets[:, :4]))]
+        results = self.model(crops, verbose=False)
+        feats = []
+        for r in results:
+            if getattr(r, "keypoints", None) is not None and len(r.keypoints.xyn):
+                kpts = r.keypoints.xyn[0].cpu().numpy()
+                parts = []
+                for idxs in self.PART_IDXS:
+                    p = kpts[idxs, :2]
+                    p = p[p.sum(1) != 0]  # filter missing
+                    parts.append(p.mean(0) if len(p) else np.zeros(2))
+                f = np.concatenate(parts).astype(np.float32)
+            else:
+                f = np.zeros(6, dtype=np.float32)
+            n = np.linalg.norm(f)
+            feats.append(f / n if n > 0 else f)
+        return feats
+
+
+class BPBreIDSORT(BOTSORT):
+    """BoT-SORT tracker with body part-based ReID."""
+
+    def __init__(self, args: Any, frame_rate: int = 30):
+        super().__init__(args, frame_rate)
+        if args.with_reid:
+            self.encoder = BodyPartReID(args.model if args.model != "auto" else "yolo11n-pose.pt")

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -10,9 +10,10 @@ from ultralytics.utils.checks import check_yaml
 
 from .bot_sort import BOTSORT
 from .byte_tracker import BYTETracker
+from .bpbreid_sort import BPBreIDSORT
 
 # A mapping of tracker types to corresponding tracker classes
-TRACKER_MAP = {"bytetrack": BYTETracker, "botsort": BOTSORT}
+TRACKER_MAP = {"bytetrack": BYTETracker, "botsort": BOTSORT, "bpbreid": BPBreIDSORT}
 
 
 def on_predict_start(predictor: object, persist: bool = False) -> None:
@@ -37,8 +38,10 @@ def on_predict_start(predictor: object, persist: bool = False) -> None:
     tracker = check_yaml(predictor.args.tracker)
     cfg = IterableSimpleNamespace(**YAML.load(tracker))
 
-    if cfg.tracker_type not in {"bytetrack", "botsort"}:
-        raise AssertionError(f"Only 'bytetrack' and 'botsort' are supported for now, but got '{cfg.tracker_type}'")
+    if cfg.tracker_type not in {"bytetrack", "botsort", "bpbreid"}:
+        raise AssertionError(
+            f"Only 'bytetrack', 'botsort' and 'bpbreid' are supported for now, but got '{cfg.tracker_type}'"
+        )
 
     predictor._feats = None  # reset in case used earlier
     if hasattr(predictor, "_hook"):


### PR DESCRIPTION
## Summary
- replace `KeypointSORT` with `BPBreIDSORT` using body part ReID
- register new tracker and document in tracker README
- update default config for `bpbreid`

## Testing
- `pytest -k track -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_684ffe04fb208328a9f96f415bbc1d98